### PR TITLE
Allow specification of hosting dir

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ module.exports = function(opts, callback) {
 
     var rawurl = url.parse(req.url);
     var pathname = decodeURI(rawurl.pathname);
-    var base = path.join(process.cwd(), opts.files);
+    var base = opts.files || process.cwd();
     var filepath = path.normalize(path.join(base, pathname));
 
     var p = path.extname(filepath).slice(1);


### PR DESCRIPTION
If you launch node-chrome from a directory that is not where you are serving files, it breaks.  

There is probably a better way to do this, so feel free to close. Just hacking together gcode-simulator stuff
